### PR TITLE
fix: remove unnecessary content from redirect page

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,5 @@
     <title>redirect-site</title>
     <meta http-equiv="refresh" content="0; url='http://zeroopensource.org/'" />
   </head>
-  <body>
-    <h1>redirect-site</h1>
-  </body>
+  <body></body>
 </html>


### PR DESCRIPTION
- Removed the heading from the body of the redirect page  
- Simplified the HTML structure of the redirect page  
- Page now only contains a meta refresh tag for immediate redirection  
- Improved clarity and reduced unnecessary markup